### PR TITLE
Relaxed the parsing of internal signals to obtain more visibility

### DIFF
--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -362,7 +362,7 @@ class PyVerilator:
     default_vcd_filename = 'gtkwave.vcd'
 
     @classmethod
-    def build(cls, top_verilog_file, verilog_path = [], build_dir = None, json_data = None, gen_only = False, trace_depth=2, top_module_name=None, auto_eval=True):
+    def build(cls, top_verilog_file, verilog_path = [], build_dir = None, json_data = None, gen_only = False, trace_depth=2, top_module_name=None, auto_eval=True, read_internal_signals=False):
         """ Build an object file from verilog and load it into python.
 
         Creates a folder build_dir in which it puts all the files necessary to create
@@ -484,7 +484,7 @@ class PyVerilator:
                 if result:
                     outputs.append(result)
                 result = search_for_signal_decl('SIG', line)
-                if result:
+                if result and read_internal_signals:
                     internal_signals.append(result)
 
         # generate the C++ wrapper file

--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -462,8 +462,7 @@ class PyVerilator:
             if result:
                 signal_name = result.group(2)
                 if signal_type == 'SIG':
-                    if signal_name.startswith(verilog_module_name) and '[' not in signal_name and int(
-                            result.group(4)) == 0:
+                    if '[' not in signal_name and int(result.group(4)) == 0:
                         # this is an internal signal
                         signal_width = int(result.group(3)) - int(result.group(4)) + 1
                         return (signal_name, signal_width)


### PR DESCRIPTION
This is required to get visibility into the actual internal hierarchy of the design from the top-level simulation object delivered by pyverilator, whereas no signal ever passes the current filtering. I think the filter may been designed with an older version of verilator.

Note: this internal signal regex/filter doesn't work for verilator 4.x, which has a completely different way of declaring internal signals in the generated C++