### PR TITLE
Correctly generate wrapper for verilator v4.012+ as well

### DIFF
--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -525,6 +525,8 @@ class PyVerilator:
             )
             if result:
                 signal_name = result.group(2)
+                # sometime after verilator 4.012, these declarations contain &s
+                signal_name = signal_name.replace("&", "")
                 if signal_type == "SIG":
                     if "[" not in signal_name and int(result.group(4)) == 0:
                         # this is an internal signal


### PR DESCRIPTION
After Verilator v4.012 the mechanism used by pyverilator for populating the signal names in pyverilator_wrapper.cpp breaks:

```
uint32_t get_&m_axis_0_tdata(Vfinn_design_wrapper* top){return top->&m_axis_0_tdata;}
uint32_t get_&m_axis_0_tvalid(Vfinn_design_wrapper* top){return top->&m_axis_0_tvalid;}
uint32_t get_&s_axis_0_tready(Vfinn_design_wrapper* top){return top->&s_axis_0_tready;}
uint32_t get_&ap_clk(Vfinn_design_wrapper* top){return top->&ap_clk;}
uint32_t get_&ap_rst_n(Vfinn_design_wrapper* top){return top->&ap_rst_n;}
uint32_t get_&m_axis_0_tready(Vfinn_design_wrapper* top){return top->&m_axis_0_tready;}
uint32_t get_&s_axis_0_tdata(Vfinn_design_wrapper* top){return top->&s_axis_0_tdata;}
uint32_t get_&s_axis_0_tvalid(Vfinn_design_wrapper* top){return top->&s_axis_0_tvalid;}
int set_&ap_clk(Vfinn_design_wrapper* top, uint32_t new_value){ top->&ap_clk = new_value; return 0;}
int set_&ap_rst_n(Vfinn_design_wrapper* top, uint32_t new_value){ top->&ap_rst_n = new_value; return 0;}
int set_&m_axis_0_tready(Vfinn_design_wrapper* top, uint32_t new_value){ top->&m_axis_0_tready = new_value; return 0;}
int set_&s_axis_0_tdata(Vfinn_design_wrapper* top, uint32_t new_value){ top->&s_axis_0_tdata = new_value; return 0;}
int set_&s_axis_0_tvalid(Vfinn_design_wrapper* top, uint32_t new_value){ top->&s_axis_0_tvalid = new_value; return 0;}
```

note the (illegal) ampersand characters in the names, since the signal declarations in V<module>.hpp start looking like:

```
    VL_IN8(&ap_clk,0,0);
    VL_IN8(&ap_rst_n,0,0);
    VL_OUT8(&m_axis_0_tdata,7,0);
    VL_IN8(&m_axis_0_tready,0,0);
    VL_OUT8(&m_axis_0_tvalid,0,0);
    VL_IN8(&s_axis_0_tdata,7,0);
    VL_OUT8(&s_axis_0_tready,0,0);
    VL_IN8(&s_axis_0_tvalid,0,0);
```

This PR contains a simple fix to remove any ampersand characters from the signal names for the pyverilator wrapper.